### PR TITLE
Fix version tag issue and update workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,10 @@ jobs:
           name: Release ${{ github.ref }}
           body: ${{ steps.changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update Major Version Tag
+        run: |
+          MAJOR_VERSION=v$(echo "${{ github.ref }}" | grep -oE '^v[0-9]+')
+          git tag -f $MAJOR_VERSION
+          git push origin $MAJOR_VERSION --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes #263

Add a step to update the git tag with the major version in the `release.yml` workflow.

* Add a new step "Update Major Version Tag" after the "Create Release" step
* Extract the major version from the full semver string and create a new git tag with just the major version
* Push the new tag to the repository using the `GITHUB_TOKEN` for authentication

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/metcalfc/changelog-generator/pull/266?shareId=7859257b-3345-48ff-94a2-400dfdd39004).