### PR TITLE
fix: add plus symbol in Git ref regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 import { getInput, setFailed, setOutput } from '@actions/core'
 import { exec as _exec } from '@actions/exec'
-import { getOctokit, context } from '@actions/github'
+import { context, getOctokit } from '@actions/github'
 
 const src = __dirname
 
@@ -13,7 +13,7 @@ async function run() {
     const fetch = getInput('fetch')
     const octokit = new getOctokit(myToken)
     const { owner, repo } = context.repo
-    const regexp = /^[.A-Za-z0-9_/-]*$/
+    const regexp = /^[.A-Za-z0-9_/\-+]*$/
 
     if (!headRef) {
       headRef = context.sha
@@ -45,7 +45,7 @@ async function run() {
       getChangelog(headRef, baseRef, owner + '/' + repo, reverse, fetch)
     } else {
       setFailed(
-        'Branch names must contain only numbers, strings, underscores, periods, forward slashes, and dashes.'
+        'Git ref names must contain only numbers, strings, underscores, periods, forward slashes, pluses, and dashes.'
       )
     }
   } catch (error) {


### PR DESCRIPTION
The current ref name regex `/^[.A-Za-z0-9_/-]*$/` does not permit '+' character, which is a valid char for Git refs.

In particular, naming Git tags using [semver](semver.org) will include the '+' char for the metadata section. This PR updates it to `/^[.A-Za-z0-9_/\-\+]*$/`.

Long-term, I would suggest deprecating the regex entirely and passing the user-provided strings to Git; if necessary they can be validated using [git-check-ref-format](https://git-scm.com/docs/git-check-ref-format#_examples).