### PR TITLE
test: replace the no-op test target with a real suite

### DIFF
--- a/.github/workflows/branchtest.yaml
+++ b/.github/workflows/branchtest.yaml
@@ -27,4 +27,3 @@ jobs:
           cat << "EOF"
           ${{ steps.changelog.outputs.changelog }}
           EOF
-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,28 @@ permissions:
 on: [push]
 
 jobs:
+  unit:
+    name: Lint and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # was: actions/checkout@v6
+      - name: Set up Node
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # was: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Check formatting
+        run: npm run format-check
+      - name: Run tests
+        run: npm test
+
   test:
+    name: End-to-end action run
     runs-on: ubuntu-latest
     steps:
       # To use this repository's private action, you must check out the repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,22 @@ I'm happy to take a look if you've got a feature you'd let to add. Please don't 
 If you've found a bug submit an issue and PR and we will get it sorted.
 
 Thanks!
+
+## Development
+
+```sh
+make install   # install dependencies
+make test      # run the test suite
+make           # lint, format-check, test, and build
+```
+
+`make test` runs the Node test runner over `test/`:
+
+- `test/changelog.test.mjs` drives `changelog.sh` against throwaway git
+  repositories built on the fly, covering ordering, the `reverse` flag, the
+  empty-base-ref fallback, refs with slashes, and failure modes.
+- `test/refs.test.mjs` covers the ref-name validation in `refs.mjs` that keeps
+  shell metacharacters out of `changelog.sh`.
+- `test/dist.test.mjs` rebuilds the bundle and fails if the committed `dist/`
+  is stale — `action.yml` runs `dist/index.js`, so it must be regenerated with
+  `make build` and committed alongside any source change.

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: all help lint format check test build clean install
 
 # Default target
-all: lint check build
+all: lint check test build
 
 # Help command
 help:
 	@echo "Available commands:"
-	@echo "  make              Run lint, check, and build"
+	@echo "  make              Run lint, check, test, and build"
 	@echo "  make help         Show this help message"
 	@echo "  make lint         Run ESLint"
 	@echo "  make format       Format code with Prettier"
@@ -44,7 +44,7 @@ check: check-node
 # Run tests
 test: check-node
 	@echo "🧪 Running tests..."
-	@npm test || echo "⚠️  No tests available. Consider adding tests."
+	@npm test
 
 # Build the project
 build: check-node

--- a/dist/index.js
+++ b/dist/index.js
@@ -45238,7 +45238,19 @@ function getOctokit(token, options, ...additionalPlugins) {
     return new GitHubWithPlugins(getOctokitOptions(token, options));
 }
 //# sourceMappingURL=github.js.map
+;// CONCATENATED MODULE: ./refs.mjs
+// Git ref names are interpolated into a shell command by changelog.sh, so they
+// are validated here before they ever reach the shell. Only characters that are
+// legal in a ref name are allowed: no spaces, quotes, semicolons, backticks or
+// dollar signs.
+const REF_PATTERN = /^[.A-Za-z0-9_/\-+]*$/
+
+function isValidRef(ref) {
+  return typeof ref === 'string' && ref.length > 0 && REF_PATTERN.test(ref)
+}
+
 ;// CONCATENATED MODULE: ./index.js
+
 
 
 
@@ -45254,7 +45266,6 @@ async function run() {
     const fetch = getInput('fetch')
     const octokit = new getOctokit(myToken)
     const { owner, repo } = github_context.repo
-    const regexp = /^[.A-Za-z0-9_/\-+]*$/
 
     if (!headRef) {
       headRef = github_context.sha
@@ -45277,12 +45288,7 @@ async function run() {
     console.log(`head-ref: ${headRef}`)
     console.log(`base-ref: ${baseRef}`)
 
-    if (
-      !!headRef &&
-      !!baseRef &&
-      regexp.test(headRef) &&
-      regexp.test(baseRef)
-    ) {
+    if (isValidRef(headRef) && isValidRef(baseRef)) {
       getChangelog(headRef, baseRef, owner + '/' + repo, reverse, fetch)
     } else {
       setFailed(

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import { getInput, setFailed, setOutput } from '@actions/core'
 import { exec as _exec } from '@actions/exec'
 import { context, getOctokit } from '@actions/github'
+import { isValidRef } from './refs.mjs'
 
 const src = __dirname
 
@@ -13,7 +14,6 @@ async function run() {
     const fetch = getInput('fetch')
     const octokit = new getOctokit(myToken)
     const { owner, repo } = context.repo
-    const regexp = /^[.A-Za-z0-9_/\-+]*$/
 
     if (!headRef) {
       headRef = context.sha
@@ -36,12 +36,7 @@ async function run() {
     console.log(`head-ref: ${headRef}`)
     console.log(`base-ref: ${baseRef}`)
 
-    if (
-      !!headRef &&
-      !!baseRef &&
-      regexp.test(headRef) &&
-      regexp.test(baseRef)
-    ) {
+    if (isValidRef(headRef) && isValidRef(baseRef)) {
       getChangelog(headRef, baseRef, owner + '/' + repo, reverse, fetch)
     } else {
       setFailed(

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "build": "ncc build ./index.js",
     "bump:readme": "sed -i \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./README.md ./SECURITY.md",
     "bump:workflow": "sed -i \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./.github/workflows/*yml",
-    "format-check": "prettier --check **/*.{js,yml,json}",
-    "format": "prettier --write **/*.{js,yml,json}",
+    "format-check": "prettier --check \"**/*.{js,mjs,yml,yaml,json}\"",
+    "format": "prettier --write \"**/*.{js,mjs,yml,yaml,json}\"",
     "lint": "eslint ./",
     "postversion": "git push && git push --tags",
     "precommit-msg": "echo 'Pre-commit checks...' && exit 0",
     "precommit": "npm run build && git add dist/",
     "refme": "npm exec gh-refme -- convert ./.github/workflows/*",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test 'test/**/*.test.mjs'",
     "version": "npm run bump:readme && npm run bump:workflow && git add ./dist ./README.md ./SECURITY.md ./.github/workflows/*yml"
   },
   "pre-commit": [

--- a/refs.mjs
+++ b/refs.mjs
@@ -1,0 +1,9 @@
+// Git ref names are interpolated into a shell command by changelog.sh, so they
+// are validated here before they ever reach the shell. Only characters that are
+// legal in a ref name are allowed: no spaces, quotes, semicolons, backticks or
+// dollar signs.
+export const REF_PATTERN = /^[.A-Za-z0-9_/\-+]*$/
+
+export function isValidRef(ref) {
+  return typeof ref === 'string' && ref.length > 0 && REF_PATTERN.test(ref)
+}

--- a/test/changelog.test.mjs
+++ b/test/changelog.test.mjs
@@ -1,0 +1,203 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+
+import {
+  captureError,
+  CHANGELOG_SH,
+  commit,
+  createRepo,
+  git,
+  line,
+  runChangelog,
+  tag
+} from './helpers/repo.mjs'
+
+test('lists the commits between two refs, newest first', t => {
+  const dir = createRepo(t)
+  const first = commit(dir, 'feat: first')
+  tag(dir, 'v0.0.1')
+  const second = commit(dir, 'feat: second')
+  const third = commit(dir, 'feat: third')
+  tag(dir, 'v0.0.2')
+
+  const out = runChangelog(dir, { head: 'v0.0.2', base: 'v0.0.1' })
+
+  assert.deepEqual(out.split('\n'), [line(third), line(second)])
+  assert.ok(!out.includes(first.sha), 'base ref commit must not be included')
+})
+
+test('reverse=true lists the commits oldest first', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: first')
+  tag(dir, 'v0.0.1')
+  const second = commit(dir, 'feat: second')
+  const third = commit(dir, 'feat: third')
+  tag(dir, 'v0.0.2')
+
+  const out = runChangelog(dir, {
+    head: 'v0.0.2',
+    base: 'v0.0.1',
+    reverse: 'true'
+  })
+
+  assert.deepEqual(out.split('\n'), [line(second), line(third)])
+})
+
+test('reverse=false is the same as omitting reverse', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: first')
+  tag(dir, 'v0.0.1')
+  commit(dir, 'feat: second')
+  commit(dir, 'feat: third')
+  tag(dir, 'v0.0.2')
+
+  const withFlag = runChangelog(dir, {
+    head: 'v0.0.2',
+    base: 'v0.0.1',
+    reverse: 'false'
+  })
+  const withoutFlag = runChangelog(dir, { head: 'v0.0.2', base: 'v0.0.1' })
+
+  assert.equal(withFlag, withoutFlag)
+})
+
+test('formats every commit as a markdown link to the commit URL', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+  const head = commit(dir, 'fix: something broke')
+
+  const out = runChangelog(dir, {
+    head: 'HEAD',
+    base: 'base',
+    repo: 'octocat/hello-world'
+  })
+
+  assert.equal(
+    out,
+    `- [${head.short}](http://github.com/octocat/hello-world/commit/${head.sha}) - fix: something broke`
+  )
+})
+
+test('an empty base ref falls back to the initial commit', t => {
+  const dir = createRepo(t)
+  const first = commit(dir, 'feat: first')
+  const second = commit(dir, 'feat: second')
+
+  const out = runChangelog(dir, { head: 'HEAD', base: '' })
+
+  // The initial commit is the fallback base, so it is excluded from its own
+  // range: everything after it shows up.
+  assert.deepEqual(out.split('\n'), [line(second)])
+  assert.ok(!out.includes(first.sha))
+})
+
+test('an empty base ref on a single-commit repo reports no changes', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: the only commit')
+
+  assert.equal(runChangelog(dir, { head: 'HEAD', base: '' }), 'No Changes.')
+})
+
+test('identical refs report no changes instead of failing', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: first')
+  tag(dir, 'v0.0.1')
+
+  assert.equal(
+    runChangelog(dir, { head: 'v0.0.1', base: 'v0.0.1' }),
+    'No Changes.'
+  )
+})
+
+test('handles branch names containing slashes', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'v1.0.0')
+  git(dir, ['checkout', '--quiet', '-b', 'test/branch'])
+  const onBranch = commit(dir, 'feat: work on a slashed branch')
+
+  const out = runChangelog(dir, { head: 'test/branch', base: 'v1.0.0' })
+
+  assert.equal(out, line(onBranch))
+})
+
+test('passes commit subjects through without shell interpretation', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+  const subjects = [
+    'fix: escape 100% of "quotes" and \'apostrophes\'',
+    'feat: support $HOME and *.txt globs',
+    'chore: a && b || c; d',
+    'docs: backticks `like this` and $(this)',
+    'refactor: unicode ✨ and emoji 🚀'
+  ]
+  const commits = subjects.map(s => commit(dir, s))
+
+  const out = runChangelog(dir, { head: 'HEAD', base: 'base' })
+
+  assert.deepEqual(
+    out.split('\n'),
+    commits.reverse().map(c => line(c))
+  )
+})
+
+test('reports only the subject line of a multi-line commit message', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+  const head = commit(dir, 'feat: subject only', 'A body that must not appear.')
+
+  const out = runChangelog(dir, { head: 'HEAD', base: 'base' })
+
+  assert.equal(out, line(head))
+  assert.ok(!out.includes('must not appear'))
+})
+
+test('fails loudly when a ref does not exist', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: first')
+
+  const err = captureError(() =>
+    runChangelog(dir, { head: 'no-such-ref', base: 'HEAD' })
+  )
+  assert.notEqual(err.status, 0)
+  assert.match(String(err.stderr), /no-such-ref/)
+})
+
+test('does not touch the network when fetch is false', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+  const head = commit(dir, 'feat: offline')
+  // A remote that cannot possibly resolve: if changelog.sh fetched anyway the
+  // `set -e` at the top of the script would abort the run.
+  git(dir, [
+    'remote',
+    'add',
+    'origin',
+    'https://0.0.0.0/metcalfc/changelog-generator.git'
+  ])
+
+  const out = runChangelog(dir, { head: 'HEAD', base: 'base', fetch: 'false' })
+
+  assert.equal(out, line(head))
+})
+
+test('exits non-zero when required arguments are missing', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: first')
+
+  // `set -u` means a missing positional argument must abort rather than
+  // silently produce a changelog against the wrong range.
+  const err = captureError(() =>
+    execFileSync(CHANGELOG_SH, ['HEAD'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  )
+  assert.notEqual(err.status, 0)
+})

--- a/test/dist.test.mjs
+++ b/test/dist.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ROOT } from './helpers/repo.mjs'
+
+// action.yml runs dist/index.js, not index.js. A stale dist/ is the classic way
+// to ship a JavaScript action that silently does the old thing, so the build
+// output is checked in and verified here.
+
+test('dist/changelog.sh matches the source script', () => {
+  const source = readFileSync(join(ROOT, 'changelog.sh'), 'utf8')
+  const shipped = readFileSync(join(ROOT, 'dist', 'changelog.sh'), 'utf8')
+
+  assert.equal(shipped, source, 'run `make build` to refresh dist/')
+})
+
+test('dist/changelog.sh is executable', () => {
+  const mode = statSync(join(ROOT, 'dist', 'changelog.sh')).mode
+  assert.equal(mode & 0o111, 0o111, 'dist/changelog.sh must be executable')
+})
+
+test('dist/index.js is an up-to-date build of index.js', t => {
+  const out = mkdtempSync(join(tmpdir(), 'changelog-generator-build-'))
+  t.after(() => rmSync(out, { recursive: true, force: true }))
+
+  execFileSync('npx', ['ncc', 'build', './index.js', '-o', out], {
+    cwd: ROOT,
+    encoding: 'utf8'
+  })
+
+  const fresh = readFileSync(join(out, 'index.js'), 'utf8')
+  const shipped = readFileSync(join(ROOT, 'dist', 'index.js'), 'utf8')
+
+  assert.equal(fresh, shipped, 'run `make build` and commit dist/')
+})

--- a/test/helpers/repo.mjs
+++ b/test/helpers/repo.mjs
@@ -1,0 +1,100 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+export const ROOT = fileURLToPath(new URL('../../', import.meta.url))
+export const CHANGELOG_SH = join(ROOT, 'changelog.sh')
+
+// Commit timestamps have to be strictly increasing for `git log` ordering to be
+// deterministic, so hand out a fresh minute for every commit the suite makes.
+let tick = 0
+function nextDate() {
+  const date = new Date(Date.UTC(2020, 0, 1, 0, 0, 0) + tick * 60_000)
+  tick += 1
+  return date.toISOString()
+}
+
+export function git(cwd, args, env = {}) {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, ...env }
+  }).trim()
+}
+
+/**
+ * A throwaway git repo, cleaned up when the test finishes.
+ */
+export function createRepo(t) {
+  const dir = mkdtempSync(join(tmpdir(), 'changelog-generator-test-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+  git(dir, ['init', '--quiet', '--initial-branch=main'])
+  git(dir, ['config', 'user.email', 'test@example.com'])
+  git(dir, ['config', 'user.name', 'Changelog Test'])
+  git(dir, ['config', 'commit.gpgsign', 'false'])
+  return dir
+}
+
+/**
+ * Commit `subject` and return the commit's short and full SHAs.
+ */
+export function commit(dir, subject, body = '') {
+  const date = nextDate()
+  writeFileSync(join(dir, 'file.txt'), `${subject}\n`)
+  git(dir, ['add', '--all'])
+  git(dir, ['commit', '--quiet', '--message', subject, '--message', body], {
+    GIT_AUTHOR_DATE: date,
+    GIT_COMMITTER_DATE: date
+  })
+
+  const sha = git(dir, ['rev-parse', 'HEAD'])
+  return { sha, short: git(dir, ['rev-parse', '--short', sha]), subject }
+}
+
+export function tag(dir, name) {
+  git(dir, ['tag', name])
+  return name
+}
+
+/**
+ * Invoke changelog.sh the same way index.js does. `fetch` defaults to false
+ * because the fixtures have no reachable remote.
+ */
+export function runChangelog(
+  dir,
+  {
+    head,
+    base = '',
+    repo = 'metcalfc/changelog-generator',
+    reverse = 'false',
+    fetch = 'false'
+  }
+) {
+  return execFileSync(CHANGELOG_SH, [head, base, repo, reverse, fetch], {
+    cwd: dir,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trimEnd()
+}
+
+/**
+ * Run `fn` and return the error it threw, failing the test if it succeeds.
+ */
+export function captureError(fn) {
+  try {
+    fn()
+  } catch (error) {
+    return error
+  }
+  throw new Error('expected the command to fail, but it succeeded')
+}
+
+/**
+ * The markdown line changelog.sh is expected to emit for a commit.
+ */
+export function line(commitInfo, repo = 'metcalfc/changelog-generator') {
+  return `- [${commitInfo.short}](http://github.com/${repo}/commit/${commitInfo.sha}) - ${commitInfo.subject}`
+}

--- a/test/refs.test.mjs
+++ b/test/refs.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { isValidRef } from '../refs.mjs'
+
+test('isValidRef accepts ref names git actually produces', () => {
+  const valid = [
+    'main',
+    'v4.7.0',
+    'HEAD',
+    'origin/test/branch',
+    'refs/tags/v1.0.0',
+    'feature_branch',
+    'dependabot/npm_and_yarn/eslint-10.8.0',
+    'release-4.x',
+    'weird+but+legal',
+    '0ea1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3',
+    '.hidden'
+  ]
+
+  for (const ref of valid) {
+    assert.equal(isValidRef(ref), true, `expected ${ref} to be valid`)
+  }
+})
+
+test('isValidRef rejects anything the shell could reinterpret', () => {
+  const invalid = [
+    'main; rm -rf /',
+    '$(whoami)',
+    '`id`',
+    'main && curl evil.sh',
+    'main | tee /tmp/x',
+    'a ref with spaces',
+    "main'",
+    'main"',
+    'main\nsecond-line',
+    'main${IFS}x',
+    '*',
+    '~/main',
+    'main#fragment',
+    'main!bang',
+    'main@{upstream}'
+  ]
+
+  for (const ref of invalid) {
+    assert.equal(
+      isValidRef(ref),
+      false,
+      `expected ${JSON.stringify(ref)} to be rejected`
+    )
+  }
+})
+
+test('isValidRef rejects empty and non-string input', () => {
+  // The action treats "no ref supplied" as a failure rather than defaulting,
+  // so the empty string must not pass even though the pattern allows it.
+  assert.equal(isValidRef(''), false)
+  assert.equal(isValidRef(undefined), false)
+  assert.equal(isValidRef(null), false)
+  assert.equal(isValidRef(42), false)
+  assert.equal(isValidRef(['main']), false)
+})


### PR DESCRIPTION
## Problem

`make test` ran `npm test || echo "⚠️  No tests available. Consider adding tests."` and `npm test` was `echo "Error: no test specified" && exit 1`. The failure was swallowed, so the target reported success no matter what the code did. Nothing in CI ran lint or format-check either.

## What's here

19 tests on the built-in Node test runner. No new dependencies.

**`test/changelog.test.mjs`** — drives the real `changelog.sh` against throwaway git repos built per test with deterministic commit timestamps. Covers ordering, `reverse=true`/`false`, the exact markdown link format, the empty-base-ref fallback to the initial commit, `No Changes.`, branch names with slashes, subjects containing `$HOME`/backticks/`&&`/quotes passing through uninterpreted, subject-only output for multi-line messages, unknown refs failing loudly, and a bogus remote proving `fetch: false` stays offline.

**`test/refs.test.mjs`** — the ref-name validation moves out of `index.js` into `refs.mjs` (`isValidRef`) so the guard keeping shell metacharacters away from `changelog.sh` can be tested directly. Same semantics as before; the `dist/index.js` diff is only that refactor.

**`test/dist.test.mjs`** — `action.yml` runs `dist/index.js`, so a stale bundle ships the old behavior silently. This rebuilds with ncc into a temp dir and diffs against the committed bundle, plus checks `dist/changelog.sh` matches source and is executable.

## Wiring

- `make test` no longer swallows failures; `make` includes it.
- `test.yml` gains a `unit` job running lint, format-check, and test.
- Prettier's globs were unquoted, so the shell mangled `**` and skipped root-level files. Quoted them and covered `.mjs`/`.yaml` — which turned up one pre-existing whitespace fix in `branchtest.yaml`.

## Verification

The suite was mutation-checked rather than just run green: removing `--reverse` and blanking `No Changes.` in `changelog.sh` fails 4 tests, and loosening `REF_PATTERN` to `/.*/` fails the injection test plus the dist-staleness test.

## Note for #441

The ncc 0.38.4 → 0.44.1 bump changes the bundler that produces `dist/index.js`, so it needs a `make build` and committed `dist/` alongside it. Once this lands, `test/dist.test.mjs` will catch that automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)