### PR TITLE
ci: bump codeql-action to v4.37.1 and group its future updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,11 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    groups:
+      # codeql-action/init, /autobuild and /analyze must all be on the same
+      # version or CodeQL-Build fails with a configuration error. Ungrouped,
+      # Dependabot opens one PR per step and each is red on its own because it
+      # leaves the other two behind.
+      codeql-action:
+        patterns:
+          - 'github/codeql-action*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc # was: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # was: github/codeql-action/init@v4
 
         # Override language selection by uncommenting this and choosing your languages
         # with:
@@ -39,7 +39,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@38697555549f1db7851b81482ff19f1fa5c4fedc # was: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7188fc363630916deb702c7fdcf4e481b751f97a # was: github/codeql-action/autobuild@v4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -53,4 +53,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc # was: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # was: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Problem

`CodeQL-Build` fails on #451, #452 and #453 with a configuration error:

> Not all workflow steps that use `github/codeql-action` actions use the same version. Please ensure that all such steps use the same version to avoid compatibility issues.

Dependabot opens one PR per step (`init`, `autobuild`, `analyze`). Each one bumps its own step and leaves the other two on the old SHA, so **none of them can go green on its own** — they've been red since July 21.

## Fix

Two parts:

1. **Apply all three at once.** All three PRs proposed the same commit, `7188fc363630916deb702c7fdcf4e481b751f97a`, which I verified dereferences from the `v4.37.1` annotated tag.
2. **Group future bumps.** A `codeql-action` group in `dependabot.yml` matching `github/codeql-action*` means subsequent version bumps arrive as one mergeable PR instead of three mutually-blocking ones.

## Follow-up

#451, #452 and #453 are superseded by this and should be closed once it lands.