### PR TITLE
fix: fail the step when the changelog cannot be generated

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,5 +1,0 @@
-{
-  "permissions": {
-    "allow": ["Bash(gh pr checks:*)", "Bash(npm outdated:*)", "Bash(cd:*)"]
-  }
-}

--- a/.github/workflows/branchtest.yaml
+++ b/.github/workflows/branchtest.yaml
@@ -14,8 +14,7 @@ jobs:
 
       - name: Generate changelog
         id: changelog
-        # refme: ignore
-        uses: metcalfc/changelog-generator@main
+        uses: ./
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           head-ref: 'origin/test/branch' #add 'origin/` in front of your branch name

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,16 +33,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # was: actions/checkout@v6
       - name: Generate changelog
         id: changelog
-        # refme: ignore
-        uses: metcalfc/changelog-generator@main
+        uses: ./
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           head-ref: 'v0.0.2'
           base-ref: 'v0.0.1'
       - name: Reverse the generated changelog
         id: changelog-rev
-        # refme: ignore
-        uses: metcalfc/changelog-generator@main
+        uses: ./
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           head-ref: 'v0.0.2'
@@ -50,8 +48,7 @@ jobs:
           reverse: 'true'
       - name: Explicitly do not reverse the generated changelog
         id: changelog-notrev
-        # refme: ignore
-        uses: metcalfc/changelog-generator@main
+        uses: ./
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
           head-ref: 'v0.0.2'
@@ -81,8 +78,7 @@ jobs:
           EOF
       - name: Generate changelog from release
         id: release
-        # refme: ignore
-        uses: metcalfc/changelog-generator@main
+        uses: ./
         with:
           myToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Get the changelog

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
 .envrc
+.claude/settings.local.json

--- a/changelog.sh
+++ b/changelog.sh
@@ -12,13 +12,22 @@ fi
 
 fetch=$5
 
-# By default a GitHub action checkout is shallow. Get all the tags, branches,
-# and history. Redirect output to standard error which we can collect in the
-# action.
+# By default a GitHub action checkout is shallow and single-branch. Get all the
+# tags, branches, and history. Redirect output to standard error which we can
+# collect in the action.
+#
+# This has to be a single fetch. Chaining --depth=1 fetches ahead of
+# --unshallow races on .git/shallow: each one rewrites the file that the next
+# one has already read, and git intermittently aborts with "shallow file has
+# changed since we read it". --unshallow is also an error on a repository that
+# is already complete, so only ask for it when there is a shallow file.
 if [ "$fetch" == "true" ]; then
-  git fetch --depth=1 origin +refs/tags/*:refs/tags/* 1>&2
-  git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/* 1>&2
-  git fetch --prune --unshallow 1>&2
+  unshallow=""
+  if [ -f "$(git rev-parse --git-path shallow)" ]; then
+    unshallow="--unshallow"
+  fi
+  # Do not quote $unshallow, for the same reason as $extra_flags below.
+  git fetch --prune --tags ${unshallow} origin '+refs/heads/*:refs/remotes/origin/*' 1>&2
 fi
 
 # if folks don't have a base ref to compare against just use the initial

--- a/dist/changelog.sh
+++ b/dist/changelog.sh
@@ -12,13 +12,22 @@ fi
 
 fetch=$5
 
-# By default a GitHub action checkout is shallow. Get all the tags, branches,
-# and history. Redirect output to standard error which we can collect in the
-# action.
+# By default a GitHub action checkout is shallow and single-branch. Get all the
+# tags, branches, and history. Redirect output to standard error which we can
+# collect in the action.
+#
+# This has to be a single fetch. Chaining --depth=1 fetches ahead of
+# --unshallow races on .git/shallow: each one rewrites the file that the next
+# one has already read, and git intermittently aborts with "shallow file has
+# changed since we read it". --unshallow is also an error on a repository that
+# is already complete, so only ask for it when there is a shallow file.
 if [ "$fetch" == "true" ]; then
-  git fetch --depth=1 origin +refs/tags/*:refs/tags/* 1>&2
-  git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/* 1>&2
-  git fetch --prune --unshallow 1>&2
+  unshallow=""
+  if [ -f "$(git rev-parse --git-path shallow)" ]; then
+    unshallow="--unshallow"
+  fi
+  # Do not quote $unshallow, for the same reason as $extra_flags below.
+  git fetch --prune --tags ${unshallow} origin '+refs/heads/*:refs/remotes/origin/*' 1>&2
 fi
 
 # if folks don't have a base ref to compare against just use the initial

--- a/dist/index.js
+++ b/dist/index.js
@@ -45255,8 +45255,6 @@ function isValidRef(ref) {
 
 
 
-const src = (/* unused pure expression or super */ null && (__dirname))
-
 async function run() {
   try {
     let headRef = getInput('head-ref')
@@ -45317,6 +45315,10 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
     }
     options.cwd = './'
 
+    // ncc's asset relocator rewrites this literal into a bundle-relative path
+    // and copies changelog.sh into dist/. Keep `__dirname` inline: hiding it
+    // behind a variable is what the relocator traces, and anything it cannot
+    // trace resolves to null at runtime.
     await exec_exec(
       __nccwpck_require__.ab + "changelog.sh",
       [headRef, baseRef, repoName, reverse, fetch],

--- a/dist/index.js
+++ b/dist/index.js
@@ -45316,9 +45316,9 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
     options.cwd = './'
 
     // ncc's asset relocator rewrites this literal into a bundle-relative path
-    // and copies changelog.sh into dist/. Keep `__dirname` inline: hiding it
-    // behind a variable is what the relocator traces, and anything it cannot
-    // trace resolves to null at runtime.
+    // and copies changelog.sh into dist/, so `__dirname` resolves inside the
+    // bundle even though the script lives next to it rather than next to this
+    // file. test/action.test.mjs runs the built bundle to prove it.
     await exec_exec(
       __nccwpck_require__.ab + "changelog.sh",
       [headRef, baseRef, repoName, reverse, fetch],
@@ -45333,13 +45333,14 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
       setOutput('changelog', output)
     } else {
       setFailed(err)
-      process.exit(1)
     }
   } catch (err) {
+    // setFailed sets a failing exit code on its own. Calling process.exit()
+    // here used to override it with 0, so a changelog that failed to generate
+    // still reported success and downstream steps saw an empty output.
     setFailed(
       `Could not generate changelog between references because: ${err.message}`
     )
-    process.exit(0)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
     options.cwd = './'
 
     // ncc's asset relocator rewrites this literal into a bundle-relative path
-    // and copies changelog.sh into dist/. Keep `__dirname` inline: hiding it
-    // behind a variable is what the relocator traces, and anything it cannot
-    // trace resolves to null at runtime.
+    // and copies changelog.sh into dist/, so `__dirname` resolves inside the
+    // bundle even though the script lives next to it rather than next to this
+    // file. test/action.test.mjs runs the built bundle to prove it.
     await _exec(
       `${__dirname}/changelog.sh`,
       [headRef, baseRef, repoName, reverse, fetch],
@@ -81,13 +81,14 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
       setOutput('changelog', output)
     } else {
       setFailed(err)
-      process.exit(1)
     }
   } catch (err) {
+    // setFailed sets a failing exit code on its own. Calling process.exit()
+    // here used to override it with 0, so a changelog that failed to generate
+    // still reported success and downstream steps saw an empty output.
     setFailed(
       `Could not generate changelog between references because: ${err.message}`
     )
-    process.exit(0)
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -3,8 +3,6 @@ import { exec as _exec } from '@actions/exec'
 import { context, getOctokit } from '@actions/github'
 import { isValidRef } from './refs.mjs'
 
-const src = __dirname
-
 async function run() {
   try {
     let headRef = getInput('head-ref')
@@ -65,8 +63,12 @@ async function getChangelog(headRef, baseRef, repoName, reverse, fetch) {
     }
     options.cwd = './'
 
+    // ncc's asset relocator rewrites this literal into a bundle-relative path
+    // and copies changelog.sh into dist/. Keep `__dirname` inline: hiding it
+    // behind a variable is what the relocator traces, and anything it cannot
+    // trace resolves to null at runtime.
     await _exec(
-      `${src}/changelog.sh`,
+      `${__dirname}/changelog.sh`,
       [headRef, baseRef, repoName, reverse, fetch],
       options
     )

--- a/test/action.test.mjs
+++ b/test/action.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { captureError, commit, createRepo, ROOT, tag } from './helpers/repo.mjs'
+
+// These run the built bundle the way the runner does: `node dist/index.js`
+// with INPUT_* environment variables. That covers the wiring the other suites
+// cannot see — argument marshalling, ncc asset relocation, the value written
+// to GITHUB_OUTPUT, and the process exit code the runner uses to decide
+// whether the step passed.
+
+const BUNDLE = join(ROOT, 'dist', 'index.js')
+
+function runAction(dir, inputs = {}) {
+  // The runner creates this file before the step starts, and @actions/core
+  // refuses to append to a path that does not exist.
+  const outputFile = join(dir, 'github-output.txt')
+  writeFileSync(outputFile, '')
+
+  const env = {
+    ...process.env,
+    INPUT_MYTOKEN: 'not-a-real-token',
+    'INPUT_HEAD-REF': 'HEAD',
+    'INPUT_BASE-REF': 'base',
+    INPUT_REVERSE: 'false',
+    // Both refs are supplied and fetch is off, so nothing reaches the network.
+    INPUT_FETCH: 'false',
+    GITHUB_REPOSITORY: 'octocat/hello-world',
+    GITHUB_OUTPUT: outputFile,
+    ...inputs
+  }
+
+  const stdout = execFileSync('node', [BUNDLE], {
+    cwd: dir,
+    encoding: 'utf8',
+    env,
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+
+  return { stdout, output: readFileSync(outputFile, 'utf8') }
+}
+
+test('the built action writes the changelog to GITHUB_OUTPUT', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+  const head = commit(dir, 'feat: shipped through the bundle')
+
+  const { output } = runAction(dir)
+
+  assert.match(output, /^changelog<</m)
+  assert.match(
+    output,
+    new RegExp(
+      `- \\[${head.short}\\]\\(http://github\\.com/octocat/hello-world/commit/${head.sha}\\) - feat: shipped through the bundle`
+    )
+  )
+})
+
+test('the built action fails the step when the changelog cannot be generated', t => {
+  const dir = createRepo(t)
+  commit(dir, 'feat: only commit')
+  tag(dir, 'base')
+
+  // Regression test. setFailed() was followed by process.exit(0), which threw
+  // away the failing exit code: the runner saw a green step, and any step
+  // consuming the changelog output got an empty string instead.
+  const err = captureError(() =>
+    runAction(dir, { 'INPUT_HEAD-REF': 'no-such-ref' })
+  )
+
+  assert.notEqual(err.status, 0, 'a failed changelog must fail the step')
+  assert.match(String(err.stdout), /::error::/)
+})
+
+test('the built action rejects refs carrying shell metacharacters', t => {
+  const dir = createRepo(t)
+  commit(dir, 'chore: base')
+  tag(dir, 'base')
+
+  const err = captureError(() =>
+    runAction(dir, { 'INPUT_HEAD-REF': 'HEAD; touch pwned' })
+  )
+
+  assert.notEqual(err.status, 0)
+  assert.match(String(err.stdout), /Git ref names must contain only/)
+  assert.ok(
+    !existsSync(join(dir, 'pwned')),
+    'the injected command must never reach the shell'
+  )
+})

--- a/test/changelog.test.mjs
+++ b/test/changelog.test.mjs
@@ -1,12 +1,16 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 import { execFileSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
 
 import {
   captureError,
   CHANGELOG_SH,
   commit,
   createRepo,
+  createShallowClone,
+  isShallow,
   git,
   line,
   runChangelog,
@@ -202,4 +206,54 @@ test('exits non-zero when required arguments are missing', t => {
     })
   )
   assert.notEqual(err.status, 0)
+})
+
+test('fetch=true deepens a shallow checkout and picks up its tags', t => {
+  const origin = createRepo(t)
+  const first = commit(origin, 'feat: first')
+  tag(origin, 'v0.0.1')
+  const second = commit(origin, 'feat: second')
+  const third = commit(origin, 'feat: third')
+  tag(origin, 'v0.0.2')
+
+  const dir = createShallowClone(t, origin)
+  assert.ok(isShallow(dir), 'fixture must start shallow, like actions/checkout')
+  assert.ok(
+    !existsSync(join(dir, '.git', 'refs', 'tags', 'v0.0.1')),
+    'fixture must start without the tags the changelog needs'
+  )
+
+  // Chaining --depth=1 fetches ahead of --unshallow used to abort here with
+  // "shallow file has changed since we read it", intermittently.
+  const out = runChangelog(dir, {
+    head: 'v0.0.2',
+    base: 'v0.0.1',
+    fetch: 'true'
+  })
+
+  assert.deepEqual(out.split('\n'), [line(third), line(second)])
+  assert.ok(!isShallow(dir), 'the repository should no longer be shallow')
+  assert.ok(!out.includes(first.sha))
+})
+
+test('fetch=true is a no-op on a checkout that is already complete', t => {
+  const origin = createRepo(t)
+  commit(origin, 'feat: first')
+  tag(origin, 'v0.0.1')
+  const second = commit(origin, 'feat: second')
+  tag(origin, 'v0.0.2')
+
+  const dir = createShallowClone(t, origin)
+  git(dir, ['fetch', '--prune', '--tags', '--unshallow', 'origin'])
+  assert.ok(!isShallow(dir))
+
+  // `git fetch --unshallow` is a fatal error on a complete repository, so the
+  // script must not ask for it unconditionally.
+  const out = runChangelog(dir, {
+    head: 'v0.0.2',
+    base: 'v0.0.1',
+    fetch: 'true'
+  })
+
+  assert.equal(out, line(second))
 })

--- a/test/changelog.test.mjs
+++ b/test/changelog.test.mjs
@@ -44,22 +44,24 @@ test('reverse=true lists the commits oldest first', t => {
   assert.deepEqual(out.split('\n'), [line(second), line(third)])
 })
 
-test('reverse=false is the same as omitting reverse', t => {
+test('reverse=false keeps the default newest-first order', t => {
   const dir = createRepo(t)
   commit(dir, 'feat: first')
   tag(dir, 'v0.0.1')
-  commit(dir, 'feat: second')
-  commit(dir, 'feat: third')
+  const second = commit(dir, 'feat: second')
+  const third = commit(dir, 'feat: third')
   tag(dir, 'v0.0.2')
 
-  const withFlag = runChangelog(dir, {
+  // Assert the order outright. Comparing this against a run that omits
+  // `reverse` proves nothing, because omitting it just takes the same
+  // 'false' the helper passes by default.
+  const out = runChangelog(dir, {
     head: 'v0.0.2',
     base: 'v0.0.1',
     reverse: 'false'
   })
-  const withoutFlag = runChangelog(dir, { head: 'v0.0.2', base: 'v0.0.1' })
 
-  assert.equal(withFlag, withoutFlag)
+  assert.deepEqual(out.split('\n'), [line(third), line(second)])
 })
 
 test('formats every commit as a markdown link to the commit URL', t => {

--- a/test/dist.test.mjs
+++ b/test/dist.test.mjs
@@ -18,6 +18,21 @@ test('dist/changelog.sh matches the source script', () => {
   assert.equal(shipped, source, 'run `make build` to refresh dist/')
 })
 
+test('the bundle resolves changelog.sh through ncc asset relocation', () => {
+  const bundle = readFileSync(join(ROOT, 'dist', 'index.js'), 'utf8')
+
+  // index.js builds the script path from `__dirname`. That only resolves in
+  // the bundle because ncc's asset relocator rewrites the literal and copies
+  // changelog.sh into dist/. If a refactor or an ncc upgrade ever leaves the
+  // path un-relocated, the action fails on every run at the exec call, and
+  // nothing else in this suite runs the bundle to catch it.
+  assert.match(
+    bundle,
+    /__nccwpck_require__\.ab \+ "changelog\.sh"/,
+    'ncc no longer relocates the changelog.sh path'
+  )
+})
+
 test('dist/changelog.sh is executable', () => {
   const mode = statSync(join(ROOT, 'dist', 'changelog.sh')).mode
   assert.equal(mode & 0o111, 0o111, 'dist/changelog.sh must be executable')

--- a/test/helpers/repo.mjs
+++ b/test/helpers/repo.mjs
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -78,6 +78,24 @@ export function runChangelog(
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe']
   }).trimEnd()
+}
+
+/**
+ * A shallow, single-branch clone of `origin` — what actions/checkout leaves
+ * behind by default, and the state the `fetch` input exists to repair.
+ */
+export function createShallowClone(t, origin) {
+  const dir = mkdtempSync(join(tmpdir(), 'changelog-generator-clone-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+  git(dir, ['clone', '--depth=1', '--no-tags', `file://${origin}`, dir])
+  git(dir, ['config', 'user.email', 'test@example.com'])
+  git(dir, ['config', 'user.name', 'Changelog Test'])
+  return dir
+}
+
+export function isShallow(dir) {
+  return existsSync(join(dir, '.git', 'shallow'))
 }
 
 /**

--- a/test/refs.test.mjs
+++ b/test/refs.test.mjs
@@ -3,7 +3,12 @@ import assert from 'node:assert/strict'
 
 import { isValidRef } from '../refs.mjs'
 
-test('isValidRef accepts ref names git actually produces', () => {
+// REF_PATTERN is a shell-safety whitelist, not a git ref validator: it also
+// admits strings git itself rejects (`foo..bar`, `foo.lock`, a leading dot).
+// That is fine for its purpose — changelog.sh passes refs to `git log`, which
+// rejects malformed ones on its own — but the tests below only claim the
+// shell-safety property.
+test('isValidRef accepts the ref names real workflows pass in', () => {
   const valid = [
     'main',
     'v4.7.0',
@@ -14,8 +19,7 @@ test('isValidRef accepts ref names git actually produces', () => {
     'dependabot/npm_and_yarn/eslint-10.8.0',
     'release-4.x',
     'weird+but+legal',
-    '0ea1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3',
-    '.hidden'
+    '0ea1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3'
   ]
 
   for (const ref of valid) {


### PR DESCRIPTION
Cleanup work that a review of today's changes turned into a real bug fix.

## The bug

`getChangelog`'s catch block called `setFailed()` and then `process.exit(0)`, which threw away the failing exit code `setFailed` had just set. Reproduced against the shipped bundle before the fix:

```
::error::Could not generate changelog between references because:
  The process '.../changelog.sh' failed with exit code 128
>>> EXIT CODE: 0
```

A ref that passes validation but doesn't resolve printed an error annotation, **exited 0**, and set no output. The step went green and anything reading `steps.<id>.outputs.changelog` got an empty string. Same run now exits 1.

The existing failure test drove `changelog.sh` directly, so it saw the script's nonzero status and never noticed `index.js` discarding it — the gap that hid this.

## New coverage

`test/action.test.mjs` runs `dist/index.js` the way the runner does: `INPUT_*` env vars, a real `GITHUB_OUTPUT` file, real exit code. It covers wiring nothing else sees — argument marshalling, ncc asset relocation, the emitted output value, and the exit code. Three cases: success writes the changelog to `GITHUB_OUTPUT`; a bad ref fails the step; a ref carrying `; touch pwned` is rejected and the file is never created.

## Also fixed

- **`test.yml` / `branchtest.yaml` ran `metcalfc/changelog-generator@main`.** Since these only trigger `on: push`, the end-to-end jobs on a branch tested *main* rather than the commit being pushed. Now `uses: ./`. This is why the jobs on #441 and #459 passed without ever exercising those branches' bundles.
- **The `reverse=false` test was vacuous** — it compared two invocations that were byte-identical, because the helper already defaults `reverse` to `'false'`. It now asserts the expected newest-first order.
- **`REF_PATTERN` is a shell-safety whitelist, not a git ref validator** — it admits `foo..bar`, `foo.lock`, leading dots. The test claimed these were "ref names git actually produces"; `git check-ref-format` disagrees. Documented accurately and dropped `.hidden`.
- **Dead `const src = __dirname`** removed; `__dirname` inlined at the call site. ncc's relocator rewrites it either way — verified, it was cosmetic, not the latent `null/changelog.sh` hazard it looked like.
- **`.claude/settings.local.json`** untracked and gitignored (committed by accident in `3f3af1f`; per-machine editor permissions, no secrets).

## Release note

This is the first user-visible behavior change since v4.7.0, so it's worth cutting a release once merged — see the discussion on exit-code semantics. Consumers relying on the old always-green behavior will now see failing steps, which is the point, but it's a behavior change worth calling out in the notes.