### PR TITLE
fix: make the version bump scripts portable

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "ncc build ./index.js",
-    "bump:readme": "sed -i \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./README.md ./SECURITY.md",
-    "bump:workflow": "sed -i \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./.github/workflows/*yml",
+    "bump:readme": "perl -pi -e \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./README.md ./SECURITY.md",
+    "bump:workflow": "perl -pi -e \"s/v[1-9][0-9]*\\.[0-9][0-9]*\\.[0-9][0-9]*/v$npm_package_version/g\" ./.github/workflows/*yml",
     "format-check": "prettier --check \"**/*.{js,mjs,yml,yaml,json}\"",
     "format": "prettier --write \"**/*.{js,mjs,yml,yaml,json}\"",
     "lint": "eslint ./",

--- a/test/release-scripts.test.mjs
+++ b/test/release-scripts.test.mjs
@@ -1,0 +1,82 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execFileSync } from 'node:child_process'
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { ROOT } from './helpers/repo.mjs'
+
+// `npm version` runs these through its `version` lifecycle script. They rewrite
+// tracked files in place, and when one fails it leaves a half-applied bump
+// behind — package.json on the new version, the docs still on the old one.
+// `sed -i` used to be GNU-only here, so the release could only be cut on Linux
+// and died partway through on macOS.
+
+const scripts = JSON.parse(
+  readFileSync(join(ROOT, 'package.json'), 'utf8')
+).scripts
+
+/**
+ * Run one of package.json's scripts against a copy of the files it edits, so
+ * the real tree is never touched.
+ */
+function runBumpScript(t, name, version, files) {
+  const dir = mkdtempSync(join(tmpdir(), 'changelog-generator-bump-'))
+  t.after(() => rmSync(dir, { recursive: true, force: true }))
+
+  mkdirSync(join(dir, '.github', 'workflows'), { recursive: true })
+  for (const file of files) {
+    cpSync(join(ROOT, file), join(dir, file))
+  }
+
+  execFileSync('sh', ['-c', scripts[name]], {
+    cwd: dir,
+    encoding: 'utf8',
+    env: { ...process.env, npm_package_version: version },
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+
+  return Object.fromEntries(
+    files.map(file => [file, readFileSync(join(dir, file), 'utf8')])
+  )
+}
+
+test('bump:readme rewrites the version in the docs', t => {
+  const out = runBumpScript(t, 'bump:readme', '9.9.9', [
+    'README.md',
+    'SECURITY.md'
+  ])
+
+  assert.match(out['README.md'], /metcalfc\/changelog-generator@v9\.9\.9/)
+  assert.ok(
+    !/v4\.\d+\.\d+/.test(out['README.md']),
+    'no old version may survive in README.md'
+  )
+  assert.match(out['SECURITY.md'], /v9\.9\.9/)
+  assert.ok(!/v4\.\d+\.\d+/.test(out['SECURITY.md']))
+})
+
+test('bump:workflow rewrites the version in the workflows', t => {
+  const out = runBumpScript(t, 'bump:workflow', '9.9.9', [
+    '.github/workflows/release.yml'
+  ])
+
+  assert.match(out['.github/workflows/release.yml'], /v9\.9\.9/)
+  assert.ok(
+    !/v4\.\d+\.\d+/.test(out['.github/workflows/release.yml']),
+    'no old version may survive in release.yml'
+  )
+})
+
+test('the bump scripts avoid GNU-only sed -i', () => {
+  // BSD sed reads the argument after -i as a backup suffix, so `sed -i "s/…/…/"`
+  // silently means something different on macOS and aborts the release.
+  for (const name of ['bump:readme', 'bump:workflow']) {
+    assert.doesNotMatch(
+      scripts[name],
+      /sed\s+-i\s+["']?s/,
+      `${name} must not use GNU-only in-place sed`
+    )
+  }
+})


### PR DESCRIPTION
Cutting a release has only ever worked on Linux. Hit while trying to tag v4.8.0.

## What happens

`bump:readme` and `bump:workflow` used `sed -i "s/…/…/g" ./README.md`. That is GNU syntax — BSD sed reads the argument after `-i` as a **backup-file suffix**, so on macOS it takes the expression as the suffix and `./README.md` as the script:

```
sed: 1: "./README.md": undefined label
```

`npm version` runs these from its `version` lifecycle script, *after* it has already written the new version into `package.json`. So the failure is not clean — it leaves:

- `package.json` + `package-lock.json` → new version
- `README.md`, `SECURITY.md`, `.github/workflows/*.yml` → old version

and the obvious retry then fails with `Git working directory not clean`, which points at the symptom rather than the cause. Introduced in `b86feab` ("drop abandoned replace package, use sed instead").

## Fix

`perl -pi -e` instead. Same expression, identical behavior on macOS and Linux, no backup files to clean up. Verified against copies of all the affected files: README, SECURITY.md and release.yml all rewrite exactly as before.

## Tests

`test/release-scripts.test.mjs` pulls the actual command strings out of `package.json` and runs them against copies in a temp dir, so the real tree is never touched. Plus a guard asserting `sed -i` does not come back.

Confirmed they catch it: reverting to the old scripts fails 3 tests, including on the substance (`no old version may survive in README.md`), not just the shape.