### PR TITLE
ci: let the stale workflow be run on demand

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,10 @@ permissions:
 on:
   schedule:
     - cron: '30 1 * * *'
+  # This is the only workflow here that nothing else triggers, so a break in it
+  # stays invisible until someone notices issues are not being marked. Allow a
+  # manual run to verify it after changing the action or its inputs.
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -13,7 +17,7 @@ jobs:
 
     steps:
       - name: Close Stale Issues
-        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # was: actions/stale@v10
+        uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # was: actions/stale@v11
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue has not had any activity in 30 days. Marking it stale. It will be closed in 14 days.'


### PR DESCRIPTION
`stale.yml` is the only workflow in this repo that nothing else triggers. It runs at 01:30 and acts on issues rather than code, so if the action or its inputs break, nothing surfaces it — the failure mode is "issues quietly stopped getting marked", noticed weeks later if at all.

That risk just went up with #462. v11 skips v10.3.0, which changed how `remove-stale-when-updated` — which this workflow sets to `true` — treats the stale-labelling event itself. Previously an `updated_at` drift past the label timestamp could make the action read its own label-add as activity, strip the label, and loop forever without closing. v11 no longer counts that as an update, so **items that were stuck in a mark/unmark loop will now actually close.** That is the intended behavior, but it is a change you want to observe deliberately rather than discover.

Adds `workflow_dispatch:` so it can be triggered and verified right after a change.

Also corrects the pin comment: the SHA `4391f3d` is `v11.0.0` (verified against the tag), but the trailing comment still said `@v10`.